### PR TITLE
🔧 220519: 페이지 컴포넌트 테스트코드 제작, 테스트 코드 리팩토링, 컴포넌트 리팩토링

### DIFF
--- a/.storybook/preview.js
+++ b/.storybook/preview.js
@@ -11,6 +11,7 @@ export const parameters = {
       date: /Date$/,
     },
   },
+  layout: "fullscreen",
 };
 
 // Gatsby's Link overrides:

--- a/content/main/masters.mdx
+++ b/content/main/masters.mdx
@@ -5,8 +5,8 @@ masters:
     image: crong
     field: 웹 프론트엔드
     name: 크롱
-    description: Crong, 웹 프론트엔드 마스터
-    introduce: "“우리 모두 꾸준히 학습하며 성장하는 행복한 개발자가 되면 좋겠습니다.”"
+    introduce: Crong, 웹 프론트엔드 마스터
+    nutshell: "“우리 모두 꾸준히 학습하며 성장하는 행복한 개발자가 되면 좋겠습니다.”"
     careers:
       - 우아한형제들 테크캠프 FE 교육 담당
       - 네이버 커넥트재단 부스트코스, 부스트캠프 FE교육 담당
@@ -27,8 +27,8 @@ masters:
     image: honux
     field: 웹 백엔드
     name: 호눅스
-    description: Honux, 웹 백엔드 마스터
-    introduce: "“남들하고 비교하면 늘 초라해 보이지만 느리더라도 내 속도로 꾸준히 가면 잘 되겠죠.”"
+    introduce: Honux, 웹 백엔드 마스터
+    nutshell: "“남들하고 비교하면 늘 초라해 보이지만 느리더라도 내 속도로 꾸준히 가면 잘 되겠죠.”"
     careers:
       - 현 코드스쿼드 웹 BE 교육 담당
       - 네카라쿠배 모두를 포함한 다수 기업을 대상으로 백엔드 및 클라우드 강의 경력
@@ -42,8 +42,8 @@ masters:
     image: ivy
     field: 모바일 안드로이드
     name: 아이비
-    description: Ivy, 모바일 안드로이드 마스터
-    introduce: "“가치 있는 무언가를 직접 만드는 과정을 즐길 수 있다면, 직접 부딪혀서 확인해보세요!”"
+    introduce: Ivy, 모바일 안드로이드 마스터
+    nutshell: "“가치 있는 무언가를 직접 만드는 과정을 즐길 수 있다면, 직접 부딪혀서 확인해보세요!”"
     careers:
       - 현 코드스쿼드, Udemy Android 앱 개발 강의
       - 2021 네이버 커넥트재단 부스트캠프 Android 앱 개발 강의
@@ -55,8 +55,8 @@ masters:
     image: jk
     field: 모바일 iOS
     name: JK
-    description: JK, 모바일 iOS 마스터
-    introduce: "“개발자가 된다는 것은 과거형이 아니라 현재 진행형이어야만 한다.”"
+    introduce: JK, 모바일 iOS 마스터
+    nutshell: "“개발자가 된다는 것은 과거형이 아니라 현재 진행형이어야만 한다.”"
     careers:
       - 현 국내 최장수 macOS/iOS 개발자 커뮤니티와 레츠스위프트 운영진
       - 삼성전자, 네이버, 금결원, GE, 빙글 등 모바일 컨설팅/iOS 강의 경력

--- a/src/@type/Master.ts
+++ b/src/@type/Master.ts
@@ -10,8 +10,8 @@ interface ScheduleType {
 export interface MasterType {
   field: string;
   name: string;
-  description: string;
   introduce: string;
+  nutshell: string;
   careers: string[];
   schedules?: ScheduleType[];
 }

--- a/src/components/SectionTitleRefac/SectionTitleRefac.tsx
+++ b/src/components/SectionTitleRefac/SectionTitleRefac.tsx
@@ -1,6 +1,5 @@
 import React from "react";
-import styled from "styled-components";
-import theme from "styles/theme";
+import styled, { useTheme } from "styled-components";
 // Typography
 import { LBody, SDisplay } from "typography";
 
@@ -10,6 +9,8 @@ interface ICourseSchedule {
 }
 
 const SectionTitle: React.FC<ICourseSchedule> = ({ title, subTitle }) => {
+  const theme = useTheme();
+
   return (
     <TitleWrapper>
       <LBody bold style={{ color: theme.color.greyScale.grey1 }}>

--- a/src/lib/testUtils/getQueryResult.ts
+++ b/src/lib/testUtils/getQueryResult.ts
@@ -1,8 +1,0 @@
-function getQueryResultData(queryResult: any, property: string) {
-  const {
-    mdx: { frontmatter },
-  } = queryResult;
-  return frontmatter[property];
-}
-
-export default getQueryResultData;

--- a/src/lib/testUtils/index.ts
+++ b/src/lib/testUtils/index.ts
@@ -1,3 +1,2 @@
 export { default as TestProvider } from "./TestProvider";
-export { default as getQueryResultData } from "./getQueryResult";
 export { default as removeLineFeed } from "./removeLineFeed";

--- a/src/pageComponents/faq/FAQ/FAQ.test.tsx
+++ b/src/pageComponents/faq/FAQ/FAQ.test.tsx
@@ -10,7 +10,8 @@ import { FAQResult } from "./FAQ.test.mock";
 // Assets
 import { TITLE } from "assets/static/phrases";
 // Libs
-import { TestProvider, getQueryResultData, removeLineFeed } from "lib/testUtils";
+import { TestProvider, removeLineFeed } from "lib/testUtils";
+import { strainMdxInfo } from "lib/utils";
 
 describe("<FAQ>", () => {
   const renderFAQ = () =>
@@ -28,7 +29,7 @@ describe("<FAQ>", () => {
   });
   it("카테고리, 질문, 대답, 최종 업데이트 날짜가 보여진다.", async () => {
     const { getByText, getAllByLabelText } = renderFAQ();
-    const lists = getQueryResultData(FAQResult, "lists");
+    const { lists } = strainMdxInfo(FAQResult);
 
     const arrowDownImages = getAllByLabelText("arrow-down");
     expect(arrowDownImages.length).toEqual(lists.length);

--- a/src/pageComponents/main/Article/Article.test.tsx
+++ b/src/pageComponents/main/Article/Article.test.tsx
@@ -10,7 +10,8 @@ import { ArticleResult } from "./Article.test.mock";
 // Assets
 import { SUBTITLE, TITLE } from "assets/static/phrases";
 // Libs
-import { TestProvider, getQueryResultData } from "lib/testUtils";
+import { TestProvider } from "lib/testUtils";
+import { strainMdxInfo } from "lib/utils";
 
 describe("<Article>", () => {
   const renderArticle = () =>
@@ -30,7 +31,7 @@ describe("<Article>", () => {
   it("카테고리 내용이 보여지며 클릭시 해당 링크의 새 차이 보여진다.", async () => {
     window.open = jest.fn();
     const { getByText } = renderArticle();
-    const articles = getQueryResultData(ArticleResult, "articles");
+    const { articles } = strainMdxInfo(ArticleResult);
 
     articles.forEach(({ category, title, link }: ArticleType) => {
       getByText(category);

--- a/src/pageComponents/main/CourseList/CourseList.test.tsx
+++ b/src/pageComponents/main/CourseList/CourseList.test.tsx
@@ -20,15 +20,15 @@ describe("<CourseList>", () => {
     getByText(LINK.MASTERS);
     getByText(LINK_DESCRIPTION.MASTERS);
 
-    const [linkEle] = getAllByRole("link");
-    expect(linkEle?.getAttribute("href")).toBe(INTERNAL.MASTERS);
+    const [mastersLink] = getAllByRole("link");
+    expect(mastersLink?.getAttribute("href")).toBe(INTERNAL.MASTERS);
   });
   it("코드투게더 링크가 보여진다..", async () => {
     const { getByText, getAllByRole } = renderCourseList();
     getByText(LINK.CODE_TOGETHER);
     getByText(LINK_DESCRIPTION.CODE_TOGETHER);
 
-    const [_, linkEle] = getAllByRole("link");
-    expect(linkEle?.getAttribute("href")).toBe(INTERNAL.CODE_TOGETHER);
+    const [_, codeTogetherLink] = getAllByRole("link");
+    expect(codeTogetherLink?.getAttribute("href")).toBe(INTERNAL.CODE_TOGETHER);
   });
 });

--- a/src/pageComponents/main/Culture/Culture.test.tsx
+++ b/src/pageComponents/main/Culture/Culture.test.tsx
@@ -10,7 +10,8 @@ import { CultureResult } from "./Culture.test.mock";
 // Assets
 import { TITLE, SUBTITLE } from "assets/static/phrases";
 // Libs
-import { TestProvider, getQueryResultData } from "lib/testUtils";
+import { TestProvider } from "lib/testUtils";
+import { strainMdxInfo } from "lib/utils";
 
 describe("<Culture>", () => {
   const renderCulture = () =>
@@ -29,7 +30,7 @@ describe("<Culture>", () => {
   });
   it("교육 및 학습 문화들에 대한 내용들이 보여진다.", async () => {
     const { getByText, getAllByAltText } = renderCulture();
-    const cultures = getQueryResultData(CultureResult, "cultures");
+    const { cultures } = strainMdxInfo(CultureResult);
 
     const images = getAllByAltText("culture-icon");
     expect(images.length).toEqual(cultures.length);

--- a/src/pageComponents/main/Culture/Culture.tsx
+++ b/src/pageComponents/main/Culture/Culture.tsx
@@ -1,10 +1,8 @@
 import React from "react";
-import styled from "styled-components";
+import styled, { useTheme } from "styled-components";
 import { graphql, useStaticQuery } from "gatsby";
 // Type
 import { CultureType } from "@type/Culture";
-// Theme
-import theme from "styles/theme";
 // Typography
 import { MBody, XLBody } from "typography";
 // Components
@@ -14,6 +12,8 @@ import icons from "assets/images/icons";
 import { SUBTITLE, TITLE } from "assets/static/phrases";
 
 const Culture: React.FC = () => {
+  const theme = useTheme();
+
   const data = useStaticQuery(CultureQuery);
   const { mdx } = data;
   const { frontmatter } = mdx;
@@ -30,13 +30,13 @@ const Culture: React.FC = () => {
               <MBody style={{ paddingBottom: "0.4rem" }}>{culture.subtitle}</MBody>
               <XLBody>{culture.title}</XLBody>
             </div>
-            <DescriptionWrapper>
+            <DescriptionList>
               {culture.description.split("\n\n").map((descriptionItem: string) => (
-                <li key={descriptionItem}>
-                  <MBody style={{ color: theme.color.greyScale.grey2 }}>{descriptionItem}</MBody>
-                </li>
+                <DescriptionItem key={descriptionItem}>
+                  <MBody>{descriptionItem}</MBody>
+                </DescriptionItem>
               ))}
-            </DescriptionWrapper>
+            </DescriptionList>
           </CultureContent>
         ))}
       </ContentWrapper>
@@ -79,12 +79,16 @@ const CultureImg = styled.img`
   height: 8rem;
 `;
 
-const DescriptionWrapper = styled.ul`
+const DescriptionList = styled.ul`
   display: flex;
   flex-direction: column;
   & > *:not(:last-child) {
     margin-bottom: 0.8rem;
   }
+`;
+
+const DescriptionItem = styled.li`
+  color: ${({ theme: { color } }) => color.greyScale.grey2};
 `;
 
 const CultureQuery = graphql`

--- a/src/pageComponents/main/Feature/Feature.test.tsx
+++ b/src/pageComponents/main/Feature/Feature.test.tsx
@@ -1,8 +1,6 @@
 import React from "react";
 import * as Gatsby from "gatsby";
 import { render } from "@testing-library/react";
-// Type
-import { CultureType } from "@type/Culture";
 // Testing-Component
 import { Feature } from ".";
 // Mocks
@@ -10,7 +8,8 @@ import { FeatureResult } from "./Feature.test.mock";
 // Assets
 import { TITLE, SUBTITLE } from "assets/static/phrases";
 // Libs
-import { TestProvider, getQueryResultData } from "lib/testUtils";
+import { TestProvider } from "lib/testUtils";
+import { strainMdxInfo } from "lib/utils";
 
 describe("<Feature>", () => {
   const renderFeature = () =>
@@ -29,9 +28,7 @@ describe("<Feature>", () => {
   });
   it("코드스쿼드 특징에 대한 제목, 부제목, 설명, 이미지가 보여진다.", async () => {
     const { getByText, getByAltText } = renderFeature();
-    const title = getQueryResultData(FeatureResult, "title");
-    const subtitle = getQueryResultData(FeatureResult, "subtitle");
-    const description = getQueryResultData(FeatureResult, "description");
+    const { title, subtitle, description } = strainMdxInfo(FeatureResult);
 
     getByText(title);
     getByText(subtitle);

--- a/src/pageComponents/main/Feature/Feature.tsx
+++ b/src/pageComponents/main/Feature/Feature.tsx
@@ -1,10 +1,8 @@
 import React from "react";
-import styled from "styled-components";
+import styled, { useTheme } from "styled-components";
 import { graphql, useStaticQuery } from "gatsby";
 // Type
 import { FeatureType } from "@type/Feature";
-// Theme
-import theme from "styles/theme";
 // Typography
 import { MBody, XLBody } from "typography";
 // Components
@@ -14,6 +12,8 @@ import images from "assets/images";
 import { SUBTITLE, TITLE } from "assets/static/phrases";
 
 const Feature: React.FC = () => {
+  const theme = useTheme();
+
   const data = useStaticQuery(FeatureQuery);
   const { mdx } = data;
   const { frontmatter } = mdx;

--- a/src/pageComponents/main/GraduateReview/GraduateReview.test.tsx
+++ b/src/pageComponents/main/GraduateReview/GraduateReview.test.tsx
@@ -10,7 +10,8 @@ import { GraduateReviewResult } from "./GraduateReview.test.mock";
 // Assets
 import { TITLE, SUBTITLE } from "assets/static/phrases";
 // Libs
-import { TestProvider, getQueryResultData } from "lib/testUtils";
+import { TestProvider } from "lib/testUtils";
+import { strainMdxInfo } from "lib/utils";
 
 describe("<GraduateReview>", () => {
   const renderGraduateReview = () =>
@@ -29,7 +30,7 @@ describe("<GraduateReview>", () => {
   });
   it("교육 및 학습 문화들에 대한 내용들이 보여진다.", async () => {
     const { getByText, getAllByAltText, getAllByText } = renderGraduateReview();
-    const interviews = getQueryResultData(GraduateReviewResult, "interviews");
+    const { interviews } = strainMdxInfo(GraduateReviewResult);
 
     const images = getAllByAltText("avatar");
     expect(images.length).toEqual(interviews.length);

--- a/src/pageComponents/main/Master/Master.test.mock.ts
+++ b/src/pageComponents/main/Master/Master.test.mock.ts
@@ -7,8 +7,8 @@ export const MasterResult = {
           image: "crong",
           field: "웹 프론트엔드",
           name: "크롱",
-          description: "Crong, 웹 프론트엔드 마스터",
-          introduce: "“우리 모두 꾸준히 학습하며 성장하는 행복한 개발자가 되면 좋겠습니다.”",
+          introduce: "Crong, 웹 프론트엔드 마스터",
+          nutshell: "“우리 모두 꾸준히 학습하며 성장하는 행복한 개발자가 되면 좋겠습니다.”",
           careers: [
             "우아한형제들 테크캠프 FE 교육 담당",
             "네이버 커넥트재단 부스트코스, 부스트캠프 FE교육 담당",
@@ -27,8 +27,8 @@ export const MasterResult = {
           image: "honux",
           field: "웹 백엔드",
           name: "호눅스",
-          description: "Honux, 웹 백엔드 마스터",
-          introduce:
+          introduce: "Honux, 웹 백엔드 마스터",
+          nutshell:
             "“남들하고 비교하면 늘 초라해 보이지만 느리더라도 내 속도로 꾸준히 가면 잘 되겠죠.”",
           careers: [
             "현 코드스쿼드 웹 BE 교육 담당",
@@ -45,8 +45,8 @@ export const MasterResult = {
           image: "ivy",
           field: "모바일 안드로이드",
           name: "아이비",
-          description: "Ivy, 모바일 안드로이드 마스터",
-          introduce:
+          introduce: "Ivy, 모바일 안드로이드 마스터",
+          nutshell:
             "“가치 있는 무언가를 직접 만드는 과정을 즐길 수 있다면, 직접 부딪혀서 확인해보세요!”",
           careers: [
             "현 코드스쿼드, Udemy Android 앱 개발 강의",
@@ -61,8 +61,8 @@ export const MasterResult = {
           image: "jk",
           field: "모바일 iOS",
           name: "JK",
-          description: "JK, 모바일 iOS 마스터",
-          introduce: "“개발자가 된다는 것은 과거형이 아니라 현재 진행형이어야만 한다.”",
+          introduce: "JK, 모바일 iOS 마스터",
+          nutshell: "“개발자가 된다는 것은 과거형이 아니라 현재 진행형이어야만 한다.”",
           careers: [
             "현 국내 최장수 macOS/iOS 개발자 커뮤니티와 레츠스위프트 운영진",
             "삼성전자, 네이버, 금결원, GE, 빙글 등 모바일 컨설팅/iOS 강의 경력",

--- a/src/pageComponents/main/Master/Master.test.tsx
+++ b/src/pageComponents/main/Master/Master.test.tsx
@@ -10,7 +10,8 @@ import { MasterResult } from "./Master.test.mock";
 // Assets
 import { TITLE, SUBTITLE, DESCRIPTION } from "assets/static/phrases";
 // Libs
-import { TestProvider, getQueryResultData } from "lib/testUtils";
+import { TestProvider } from "lib/testUtils";
+import { strainMdxInfo } from "lib/utils";
 
 describe("<Master>", () => {
   const renderMaster = () =>
@@ -30,7 +31,7 @@ describe("<Master>", () => {
   });
   it("마스터들의 분야에 대한 탭이 보여진다.", async () => {
     const { getByText } = renderMaster();
-    const masters = getQueryResultData(MasterResult, "masters");
+    const { masters } = strainMdxInfo(MasterResult);
 
     masters.forEach(({ field }: MasterType) => {
       getByText(field);
@@ -60,13 +61,14 @@ describe("<Master>", () => {
   };
   it("최초 렌더링시 첫번째 마스터에 대한 내용들이 보여진다.", async () => {
     const utils = renderMaster();
-    const [firstMaster] = getQueryResultData(MasterResult, "masters");
+    const { masters } = strainMdxInfo(MasterResult);
+    const [firstMaster] = masters;
 
     testMasterRendering(firstMaster, utils);
   });
   it("각 탭을 클릭하면 해당되는 마스터에 대한 내용들이 보여진다.", async () => {
     const utils = renderMaster();
-    const masters = getQueryResultData(MasterResult, "masters");
+    const { masters } = strainMdxInfo(MasterResult);
     const fields = masters.map(({ field }: MasterType) => field);
 
     masters.forEach((master: MasterType, index: number) => {

--- a/src/pageComponents/main/Master/Master.test.tsx
+++ b/src/pageComponents/main/Master/Master.test.tsx
@@ -38,14 +38,14 @@ describe("<Master>", () => {
     });
   });
   const testMasterRendering = (
-    { name, description, introduce, careers, schedules }: MasterType,
+    { name, introduce, nutshell, careers, schedules }: MasterType,
     utils: RenderResult
   ) => {
     const { getByAltText, getAllByAltText, getByText } = utils;
     getByAltText("profile");
     getByText(name);
-    getByText(description);
     getByText(introduce);
+    getByText(nutshell);
     careers.forEach((career: string) => {
       getByText(career);
     });

--- a/src/pageComponents/main/Master/Master.tsx
+++ b/src/pageComponents/main/Master/Master.tsx
@@ -50,10 +50,10 @@ const Master: React.FC = () => {
               <NicknameWrapper>
                 <XLBody>{masterIntroduce.name}</XLBody>
                 <XSBody style={{ color: `${theme.color.greyScale.grey2}`, paddingLeft: "0.8rem" }}>
-                  {masterIntroduce.description}
+                  {masterIntroduce.introduce}
                 </XSBody>
               </NicknameWrapper>
-              <MBody bold>{masterIntroduce.introduce}</MBody>
+              <MBody bold>{masterIntroduce.nutshell}</MBody>
               <CareerWrapper>
                 {masterIntroduce.careers?.map((career) => (
                   <li key={career}>
@@ -192,8 +192,8 @@ const MasterQuery = graphql`
           image
           field
           name
-          description
           introduce
+          nutshell
           careers
           schedules {
             title

--- a/src/pageComponents/main/Master/Master.tsx
+++ b/src/pageComponents/main/Master/Master.tsx
@@ -1,10 +1,8 @@
 import React from "react";
-import styled from "styled-components";
+import styled, { useTheme } from "styled-components";
 import { graphql, useStaticQuery } from "gatsby";
 // Type
 import { MasterType } from "@type/Master";
-// Theme
-import theme from "styles/theme";
 // Typography
 import { MBody, SBody, XLBody, XSBody } from "typography";
 // Components
@@ -14,6 +12,8 @@ import icons from "assets/images/icons";
 import { SUBTITLE, TITLE, DESCRIPTION } from "assets/static/phrases";
 
 const Master: React.FC = () => {
+  const theme = useTheme();
+
   const data = useStaticQuery(MasterQuery);
   const { mdx } = data;
   const { frontmatter } = mdx;

--- a/src/pageComponents/main/Place/Place.tsx
+++ b/src/pageComponents/main/Place/Place.tsx
@@ -1,10 +1,8 @@
 import React from "react";
-import styled from "styled-components";
+import styled, { useTheme } from "styled-components";
 import { graphql, useStaticQuery } from "gatsby";
 // Type
 import { PlaceType } from "@type/Place";
-// Theme
-import theme from "styles/theme";
 // Typography
 import { MBody } from "typography";
 // Components
@@ -16,6 +14,8 @@ import places from "assets/images/places";
 import { SUBTITLE, TITLE, DESCRIPTION } from "assets/static/phrases";
 
 const Place: React.FC = () => {
+  const theme = useTheme();
+
   const data = useStaticQuery(PlaceQuery);
   const { mdx } = data;
   const { frontmatter } = mdx;

--- a/src/pageComponents/recruit/JobPosition/JobPosition.test.tsx
+++ b/src/pageComponents/recruit/JobPosition/JobPosition.test.tsx
@@ -10,7 +10,8 @@ import { JobPositionResult } from "./JobPosition.test.mock";
 // Assets
 import { TITLE } from "assets/static/phrases";
 // Libs
-import { TestProvider, getQueryResultData, removeLineFeed } from "lib/testUtils";
+import { TestProvider, removeLineFeed } from "lib/testUtils";
+import { strainMdxInfo } from "lib/utils";
 
 describe("<JobPosition>", () => {
   const renderJobPosition = () =>
@@ -28,7 +29,7 @@ describe("<JobPosition>", () => {
   });
   it("채용 분야, 포지션, 채용 정보, 최종 업데이트 날짜가 보여진다.", async () => {
     const { getByText, getAllByLabelText } = renderJobPosition();
-    const jobPositions = getQueryResultData(JobPositionResult, "jobPositions");
+    const { jobPositions } = strainMdxInfo(JobPositionResult);
 
     const arrowDownImages = getAllByLabelText("arrow-down");
     expect(arrowDownImages.length).toEqual(jobPositions.length);

--- a/src/pageComponents/refund/RefundPolicy/RefundPolicy.test.mock.ts
+++ b/src/pageComponents/refund/RefundPolicy/RefundPolicy.test.mock.ts
@@ -1,0 +1,12 @@
+export const RefundPolicyResult = {
+  mdx: {
+    frontmatter: {
+      policies: [
+        { index: 1, reason: "코스 시작전까지", standard: "기 납부한 수강료 전액 환급" },
+        { index: 2, reason: "코스 진행 1/3 경과 전", standard: "수강료의 2/3 해당액 환급" },
+        { index: 3, reason: "코스 진행 1/2 경과 전", standard: "수강료의 1/2 해당액 환급" },
+        { index: 4, reason: "코스 진행 1/2 경과 후", standard: "환급하지 않음" },
+      ],
+    },
+  },
+};

--- a/src/pageComponents/refund/RefundPolicy/RefundPolicy.test.tsx
+++ b/src/pageComponents/refund/RefundPolicy/RefundPolicy.test.tsx
@@ -1,0 +1,52 @@
+import React from "react";
+import * as Gatsby from "gatsby";
+import { render } from "@testing-library/react";
+// Type
+import { RefundPolicyType } from "@type/RefundPolicy";
+// Testing-Component
+import { RefundPolicy } from ".";
+// Mocks
+import { RefundPolicyResult } from "./RefundPolicy.test.mock";
+// Assets
+import { DESCRIPTION, TITLE } from "assets/static/phrases";
+// Libs
+import { TestProvider, removeLineFeed } from "lib/testUtils";
+import { strainMdxInfo } from "lib/utils";
+
+describe("<RefundPolicy>", () => {
+  const renderRefundPolicy = () =>
+    render(
+      <TestProvider>
+        <RefundPolicy />
+      </TestProvider>
+    );
+  const useStaticQuery = jest.spyOn(Gatsby, "useStaticQuery");
+  useStaticQuery.mockImplementation(() => ({ ...RefundPolicyResult }));
+  it("제목이 보여진다.", async () => {
+    const { getByText } = renderRefundPolicy();
+
+    getByText(removeLineFeed(TITLE.REFUND_POLICY));
+  });
+  it("최종 업데이트 날짜가 보여진다.", async () => {
+    const { getByText } = renderRefundPolicy();
+    const { editDate } = strainMdxInfo(RefundPolicyResult);
+
+    getByText(`🗓 최종 업데이트: ${editDate}`);
+  });
+  it("환불규정에 대한 표가 보여진다.", async () => {
+    const { getByText } = renderRefundPolicy();
+    const { policies } = strainMdxInfo(RefundPolicyResult);
+
+    getByText(TITLE.REFUND_REASON);
+    getByText(TITLE.REFUND_STANDARD);
+    policies.forEach(({ reason, standard }: RefundPolicyType) => {
+      getByText(reason);
+      getByText(standard);
+    });
+  });
+  it("안내 문구가 보여진다.", async () => {
+    const { getByText } = renderRefundPolicy();
+
+    getByText(removeLineFeed(DESCRIPTION.REFUND));
+  });
+});

--- a/src/pageComponents/refund/RefundPolicy/RefundPolicy.tsx
+++ b/src/pageComponents/refund/RefundPolicy/RefundPolicy.tsx
@@ -22,7 +22,7 @@ const RefundPolicy: React.FC = () => {
           {TITLE.REFUND_POLICY}
         </LDisplay>
         <PolicySpecificationWrapper>
-          <MBody style={{ paddingBottom: "4rem" }}>{`최종 업데이트: ${editDate}`}</MBody>
+          <MBody style={{ paddingBottom: "4rem" }}>{`🗓 최종 업데이트: ${editDate}`}</MBody>
           <div style={{ paddingBottom: "1.6rem" }}>
             <RefundPolicyTable>
               <thead>

--- a/src/pages/faq/faq.stories.tsx
+++ b/src/pages/faq/faq.stories.tsx
@@ -1,0 +1,14 @@
+import React from "react";
+// Type
+import { ComponentStory, ComponentMeta } from "@storybook/react";
+// Story-Component
+import FAQPage from ".";
+
+export default {
+  title: "page/faq",
+  component: FAQPage,
+} as ComponentMeta<typeof FAQPage>;
+
+const Template: ComponentStory<typeof FAQPage> = () => <FAQPage />;
+
+export const Default = Template.bind({});

--- a/src/pages/masters/index.tsx
+++ b/src/pages/masters/index.tsx
@@ -9,7 +9,6 @@ import { DetailCurriculum } from "pageComponents/masters/DetailCurriculum";
 import { InterviewSliderWrapper } from "pageComponents/masters/InterviewSliderWrapper";
 import { CourseSchedule } from "pageComponents/masters/CourseSchedule";
 import { FAQ } from "pageComponents/masters/FAQ";
-import { Recruit } from "pageComponents/masters/Recruit";
 import { Footer } from "components/Footer";
 
 const MatsersPage: React.FC = () => {

--- a/src/pages/recruit/recruit.stories.tsx
+++ b/src/pages/recruit/recruit.stories.tsx
@@ -1,0 +1,14 @@
+import React from "react";
+// Type
+import { ComponentStory, ComponentMeta } from "@storybook/react";
+// Story-Component
+import RecruitPage from ".";
+
+export default {
+  title: "page/recruit",
+  component: RecruitPage,
+} as ComponentMeta<typeof RecruitPage>;
+
+const Template: ComponentStory<typeof RecruitPage> = () => <RecruitPage />;
+
+export const Default = Template.bind({});

--- a/src/pages/refund/refund.stories.tsx
+++ b/src/pages/refund/refund.stories.tsx
@@ -1,0 +1,14 @@
+import React from "react";
+// Type
+import { ComponentStory, ComponentMeta } from "@storybook/react";
+// Story-Component
+import RefundPage from ".";
+
+export default {
+  title: "page/refund",
+  component: RefundPage,
+} as ComponentMeta<typeof RefundPage>;
+
+const Template: ComponentStory<typeof RefundPage> = () => <RefundPage />;
+
+export const Default = Template.bind({});


### PR DESCRIPTION
### 페이지 컴포넌트 테스트코드 제작
* refund

### 테스트 코드 리팩토링
* getQueryResultData대신 strainMdxInfo 유틸함수를 사용하도록 수정

### 컴포넌트 리팩토링
* useTheme 을 사용하도록 수정