### PR TITLE
🔧 220523: Figma와 동일한 두께로 글자들이 렌더링되도록 옵션 추가

### DIFF
--- a/src/styles/GlobalStyle.tsx
+++ b/src/styles/GlobalStyle.tsx
@@ -37,6 +37,8 @@ html {
 body {
   line-height: 1;
   font-family: 'Noto Sans KR';
+  -webkit-font-smoothing: antialiased;
+  -moz-osx-font-smoothing: grayscale;
 }
 ol, ul {
 	list-style: none;


### PR DESCRIPTION
### Figma와 동일한 두께로 글자들이 렌더링되도록 옵션 추가
* https://github.com/code-squad/homepage/issues/66#issuecomment-1134165079 에 관련 내용을 코멘트로 작성