### PR TITLE
💄 220902: 배경이미지가 백그라운드 영역 전체에 그려지도록 수정

### DIFF
--- a/src/components/CourseInfo/CourseInfo.tsx
+++ b/src/components/CourseInfo/CourseInfo.tsx
@@ -100,7 +100,7 @@ const CourseInfoWrapper = styled.div<{ backgroundImage: string; backgroundColor:
   @media ${({ theme }) => theme.device.tablet} {
     min-width: 60.8rem;
     padding: 16rem 8rem 5.6rem 8rem;
-    background-size: contain;
+    background-size: cover;
   }
   @media ${({ theme }) => theme.device.desktop} {
     align-items: center;


### PR DESCRIPTION
### 배경이미지가 백그라운드 영역 전체에 그려지도록 수정
* 컨텐츠가 많아지면 컨텐츠 영역의 높이가 배경이미지의 높이보다 높아지기때문