### PR TITLE
🔧 220905: 선언부에서 window 객체를 참조하지 않고 핸들러에서 참조하도록 변경

### DIFF
--- a/src/pageComponents/main/Banner/Banner.tsx
+++ b/src/pageComponents/main/Banner/Banner.tsx
@@ -10,10 +10,10 @@ import { strainMdxInfo } from "lib/utils";
 
 const Banner: React.FC<IBannerProps> = ({ setBannerStatus }) => {
   const { title, description, to } = strainMdxInfo(useStaticQuery(BannerContentQuery));
-  const localStorage = typeof window !== "undefined" ? window.localStorage : null;
 
   const closeHandler = () => {
     const oneDaySec = 86400000;
+    const localStorage = typeof window !== "undefined" ? window.localStorage : null;
 
     localStorage?.setItem("maxAge", `${Date.now() + oneDaySec}`);
 


### PR DESCRIPTION
### 선언부에서 window 객체를 참조하지 않고 핸들러에서 참조하도록 변경
* 선언부에서 window객체를 참조하면 항상 undefined가 반환되어 올바른 동작을 하지 않음