### PR TITLE
🔧 220920: GNB 수정, Footer 수정, FAQ 수정

### DIFF
--- a/src/assets/static/phrases.ts
+++ b/src/assets/static/phrases.ts
@@ -128,6 +128,7 @@ const MESSAGE = {
 const CATEGORTY_TPL: { [key: string]: string } = {
   masters: "마스터즈 코스",
   javascript: "코드투게더 JS 과정",
+  "pre-course": "프리코스",
   etc: "기타",
 };
 

--- a/src/components/DropdownItem/DropdownItem.tsx
+++ b/src/components/DropdownItem/DropdownItem.tsx
@@ -99,6 +99,7 @@ const DropdownItem: React.FC<IDropdownItem> = ({
 const DropdownWrapper = styled.div<{ short?: boolean }>`
   display: flex;
   flex-direction: column;
+  white-space: pre-line;
   @media ${({ theme }) => theme.device.mobile} {
     margin-top: 1.6rem;
   }

--- a/src/components/FAQ/FAQ.tsx
+++ b/src/components/FAQ/FAQ.tsx
@@ -60,7 +60,6 @@ const FAQWrapper = styled.div`
   display: flex;
   flex-direction: column;
   width: 100%;
-  white-space: pre-line;
   @media ${({ theme }) => theme.device.mobile} {
     padding: 0 2.4rem;
     padding-bottom: 8rem;

--- a/src/components/Footer/Footer.test.tsx
+++ b/src/components/Footer/Footer.test.tsx
@@ -73,7 +73,11 @@ describe("<Footer>", () => {
         path: INTERNAL.RECRUIT,
       },
       {
-        name: LINK.MASTERS,
+        name: LINK.PRE_COURSE,
+        path: INTERNAL.PRE_COURSE,
+      },
+      {
+        name: LINK.MASTERS_MAX,
         path: INTERNAL.MASTERS,
       },
       {

--- a/src/components/Footer/Footer.tsx
+++ b/src/components/Footer/Footer.tsx
@@ -82,7 +82,10 @@ const Footer: React.FC = () => {
                 <Typography type="XSBold">{MESSAGE.CURRICULUM}</Typography>
               </li>
               <li>
-                <InternalLink to={INTERNAL.MASTERS}>{LINK.MASTERS}</InternalLink>
+                <InternalLink to={INTERNAL.PRE_COURSE}>{LINK.PRE_COURSE}</InternalLink>
+              </li>
+              <li>
+                <InternalLink to={INTERNAL.MASTERS}>{LINK.MASTERS_MAX}</InternalLink>
               </li>
               <li>
                 <InternalLink to={INTERNAL.CODE_TOGETHER}>{LINK.CODE_TOGETHER}</InternalLink>

--- a/src/components/HomeGlobalNavigationBar/HomeGlobalNavigationBar.tsx
+++ b/src/components/HomeGlobalNavigationBar/HomeGlobalNavigationBar.tsx
@@ -123,6 +123,7 @@ const HomeGlobalNavigationBar: React.FC<{ bannerStatus?: boolean }> = ({ bannerS
                       {title}
                     </LinkPopoverButton>
                     <LinkButtonWrapper open={subLinkOpen}>
+                      <EmptySpace />
                       {subLinks.map(({ title, path }: any) => (
                         <li key={title}>
                           <LinkButton selected={false} to={path}>
@@ -233,13 +234,20 @@ const LinkButtonWrapper = styled.div<{ open?: boolean }>`
   flex-direction: column;
   align-items: center;
   background-color: ${({ theme: { color } }) => color.white};
-  margin-top: 2.4rem;
+  margin-top: 3.6rem;
   transform: translate(-25%, 0);
   padding: 2.4rem 1.6rem;
   transition: opacity 0.15s linear;
   & > *:not(:last-child) {
     margin-bottom: 1.6rem;
   }
+`;
+
+const EmptySpace = styled.div`
+  position: absolute;
+  width: 100%;
+  height: 1.4rem;
+  top: -1rem;
 `;
 
 const LinkPopoverButton = styled.button<{ selected?: boolean }>`

--- a/src/components/HomeGlobalNavigationBar/HomeGlobalNavigationBar.tsx
+++ b/src/components/HomeGlobalNavigationBar/HomeGlobalNavigationBar.tsx
@@ -258,12 +258,14 @@ const LinkPopoverButton = styled.button<{ selected?: boolean }>`
   line-height: ${({ theme: { lineHeight } }) => lineHeight.body.sm};
   letter-spacing: ${({ theme: { letterSpacing } }) => letterSpacing};
   text-decoration: ${({ selected }) => (selected ? "underline" : "none")};
+  border: 0;
+  padding: 0;
+  background-color: transparent;
+  cursor: pointer;
+  font-family: inherit;
   &:hover {
     text-decoration: underline;
   }
-  border: 0;
-  background-color: transparent;
-  cursor: pointer;
 `;
 
 const LinkButton = styled(Link)<{ selected?: boolean }>`

--- a/src/components/HomeGlobalNavigationBar/MobileNavigationList/MobileNavigationList.tsx
+++ b/src/components/HomeGlobalNavigationBar/MobileNavigationList/MobileNavigationList.tsx
@@ -16,7 +16,6 @@ const MobileNavigationList: React.FC<{
   setOpen: (setOpen: boolean) => void;
 }> = ({ links, open, setOpen }) => {
   const currentPath = getCurrentPath();
-  const currentFirstPath = currentPath.split("/")[1];
 
   const linkIconList = [
     { icon: icons.medium, to: EXTERNAL.BLOG },
@@ -29,20 +28,9 @@ const MobileNavigationList: React.FC<{
     <NavigationListWrapper {...{ open }}>
       <ButtonList>
         {links.map(({ title, path, subLinks }) => {
-          let subLinkSelected = subLinks
-            ? subLinks.find((subLink) => subLink.path === currentPath)
-            : false;
-
           return (
             <li key={title}>
-              <LinkButton
-                selected={
-                  currentPath === path ||
-                  currentFirstPath === path.split("/")[1] ||
-                  Boolean(subLinkSelected)
-                }
-                to={subLinks ? "" : path}
-              >
+              <LinkButton selected={false} to={subLinks ? "" : path}>
                 {title}
               </LinkButton>
               {subLinks && (
@@ -52,6 +40,7 @@ const MobileNavigationList: React.FC<{
                       key={title}
                       to={path}
                       onClick={() => path === currentPath && setOpen(false)}
+                      selected={currentPath === path}
                     >
                       {title}
                     </SubLinkButton>
@@ -103,7 +92,7 @@ const NavigationListWrapper = styled.div<{ open: boolean }>`
 const ButtonList = styled.ul`
   display: flex;
   flex-direction: column;
-  margin-top: 8rem;
+  margin-top: 3.2rem;
   padding: 0 2.4rem;
   & > *:not(:last-child) {
     margin-bottom: 2.4rem;


### PR DESCRIPTION
### GNB 수정 #220
* Popover 위치를 피그마 문서를 준수하도록 변경
* 모바일 GNB에서 마스터즈가 아닌 프리코스, 마스터즈max 링크에 밑줄이 보여지도록 변경

### Footer 수정
* 마스터즈 코스 -> 프리코스, 마스터즈max로 분리

### FAQ/DropdownItem 수정
* DropdownItem에서 나타내는 내용이 개행이 되지 않는문제 수정