### PR TITLE
🔧 220921: 링크버튼 모바일 사양 적용

### DIFF
--- a/src/components/LinkButton/LinkButton.tsx
+++ b/src/components/LinkButton/LinkButton.tsx
@@ -29,14 +29,19 @@ const LinkButton: React.FC<ILinkButton> = ({ description, title, to, icon, capti
       target={caption || external ? "_blank" : undefined}
       rel={caption || external ? "noopener noreferrer nofollow" : undefined}
     >
-      <div>
+      <div style={{ width: isMobile ? "100%" : "auto" }}>
         {description ? (
           <Description>
             <Typography type={isMobile ? "XSBold" : "SBold"}>{description}</Typography>
           </Description>
         ) : null}
         <Title>
-          <Typography type={isMobile ? "MBold" : "SHLBold"}>{title}</Typography>
+          <Typography
+            type={isMobile ? "MBold" : "SHLBold"}
+            style={{ minWidth: isMobile ? "9.288rem" : "auto" }}
+          >
+            {title}
+          </Typography>
           <img aria-label="arrow-right" src={icons.chevronRight} width="24px" height="24px" />
         </Title>
         {caption ? (
@@ -99,6 +104,10 @@ const Title = styled.div`
   display: flex;
   align-items: center;
   color: ${({ theme: { color } }) => color.black};
+  @media ${({ theme }) => theme.device.mobile} {
+    justify-content: space-between;
+    width: 100%;
+  }
 `;
 const Caption = styled.div`
   margin-top: 0.8rem;


### PR DESCRIPTION
### 링크버튼 모바일 사양 적용
* 모바일일 경우에는 chevronRight 이미지가 링크버튼 끝에 붙어보이도록 수정
* 최소 크기 설정하여 마스터즈*max가 개행되지 않도록 변경