### PR TITLE
🔧 220921: FAQ 태그 이름을 마스터즈 코스->마스터즈로 변경

### DIFF
--- a/src/assets/static/phrases.ts
+++ b/src/assets/static/phrases.ts
@@ -127,7 +127,7 @@ const MESSAGE = {
 };
 
 const CATEGORTY_TPL: { [key: string]: string } = {
-  masters: "마스터즈 코스",
+  masters: "마스터즈",
   javascript: "코드투게더 JS 과정",
   "pre-course": "프리코스",
   etc: "기타",


### PR DESCRIPTION
### FAQ 태그 이름을 마스터즈 코스->마스터즈로 변경