### PR TITLE
🔧 221223: 클린 스위프트 관련 내용 수정

### DIFF
--- a/content/code-together/courses.mdx
+++ b/content/code-together/courses.mdx
@@ -21,7 +21,7 @@ courses:
     title: 클린 스위프트
     cost: 880,000원
     img: mediumSwift
-    path: https://docs.google.com/forms/d/e/1FAIpQLSe4gEzbZXRAG_Fgj31QOBvaRWLsPjb9NqaXqsLcZN7meLSvQA/viewform?pli=1
+    path: /code-together/course/clean-swift
     tags:
-      - 종료
+      - 대기자 모집 중
 ---

--- a/src/assets/static/phrases.ts
+++ b/src/assets/static/phrases.ts
@@ -133,6 +133,7 @@ const CATEGORTY_TPL: { [key: string]: string } = {
   "pre-course": "프리코스",
   etc: "기타",
   "clean-frontend": "클린 프론트엔드",
+  "clean-swift": "클린 스위프트",
 };
 
 export { DESCRIPTION, LINK_DESCRIPTION, LINK, MESSAGE, SUBTITLE, TITLE, CATEGORTY_TPL };

--- a/src/pageComponents/faq/FAQ/FAQ.tsx
+++ b/src/pageComponents/faq/FAQ/FAQ.tsx
@@ -17,7 +17,10 @@ import { useResponsive } from "lib/hooks";
 const FAQ: React.FC = () => {
   const { lists }: { lists: FAQType[] } = strainMdxInfo(useStaticQuery(FAQQuery));
   const categories = new Set<string>([]);
-  lists.forEach(({ course }) => categories.add(course || "etc"));
+  lists.forEach(({ course }) => {
+    if (course) categories.add(course || "etc");
+  });
+  categories.add("etc");
 
   const { isDesktop, isMobile } = useResponsive();
 


### PR DESCRIPTION
### 클린 스위프트 관련 내용 수정
* 카테고리 문구에 클린 스위프트 추가
* FAQ 페이지에서 기타 버튼이 마지막에 위치하도록 수정
* 코드투게더의 교육과정 중 클린 스위프트의 상태를 '대기자 모집 중'으로 변경, 클릭시 클린 스위프트 페이지로 이동되도록 수정