### PR TITLE
🔧 231006: 프리코스 페이지 제거, 디자인 수정

### DIFF
--- a/content/faq/lists.mdx
+++ b/content/faq/lists.mdx
@@ -111,8 +111,6 @@ lists:
     content: "매년 상반기, 하반기에 한 번씩 오픈 예정입니다. 정확한 일정은 미정이며, 시기도 변경될 수 있습니다.\n
 대기자로 등록하시면 이메일로 모집 소식을 전해드리고 있습니다."
     editDate: "2022-06-14"
-    btnText: "temp"
-    btnUrl: "/temp"
 
   - course: javascript
     category: 교육 과정

--- a/src/assets/static/seo.ts
+++ b/src/assets/static/seo.ts
@@ -1,6 +1,6 @@
 const SEO_TITLE = {
   MAIN: "코드스쿼드",
-  MASTERS: "마스터즈 코스",
+  MASTERS: "마스터즈",
   PRE_COURSE: "프리코스",
   CODE_TOGETHER: "코드투게더",
   FAQ: "자주 묻는 질문",

--- a/src/components/FAQ/FAQ.tsx
+++ b/src/components/FAQ/FAQ.tsx
@@ -105,8 +105,8 @@ const FAQListQuery = graphql`
           title
           category
           course
-          btnText
-          btnUrl
+          # btnText 더미 데이터로 사용되던 btn관련 정보 우선 주석처리
+          # btnUrl
         }
       }
     }

--- a/src/components/HomeGlobalNavigationBar/HomeGlobalNavigationBar.tsx
+++ b/src/components/HomeGlobalNavigationBar/HomeGlobalNavigationBar.tsx
@@ -61,16 +61,6 @@ const HomeGlobalNavigationBar: React.FC<{ bannerStatus?: boolean }> = ({ bannerS
     {
       title: LINK.MASTERS,
       path: INTERNAL.MASTERS,
-      subLinks: [
-        {
-          title: LINK.PRE_COURSE,
-          path: INTERNAL.PRE_COURSE,
-        },
-        {
-          title: LINK.MASTERS_MAX,
-          path: INTERNAL.MASTERS,
-        },
-      ],
     },
     {
       title: LINK.CODE_TOGETHER,

--- a/src/pageComponents/main/CourseList/CourseList.tsx
+++ b/src/pageComponents/main/CourseList/CourseList.tsx
@@ -12,18 +12,18 @@ const CourseList: React.FC = () => {
     <CourseWrapper>
       <TitleSet title={TITLE.VIEW_COURSES}></TitleSet>
       <CourseListWrapper>
-        <LinkButton
+        {/* <LinkButton
           to={INTERNAL.PRE_COURSE}
           title={LINK.PRE_COURSE}
           description={LINK_DESCRIPTION.PRE_COURSE}
           icon={thumbnails.mediumCodeTogether}
-        />
-        {/* <LinkButton
+        /> */}
+        <LinkButton
           to={INTERNAL.MASTERS}
-          title={LINK.MASTERS_MAX}
+          title={LINK.MASTERS}
           description={LINK_DESCRIPTION.MASTERS}
           icon={thumbnails.mediumMastersCourse}
-        /> */}
+        />
         <LinkButton
           to={INTERNAL.CODE_TOGETHER}
           title={LINK.CODE_TOGETHER}

--- a/src/pageComponents/masters/Masthead/Masthead.tsx
+++ b/src/pageComponents/masters/Masthead/Masthead.tsx
@@ -2,7 +2,7 @@ import React from "react";
 import { useTheme } from "styled-components";
 import { graphql, useStaticQuery } from "gatsby";
 // Components
-import { SubCourseInfo } from "components";
+import { CourseInfo } from "components";
 // Assets
 import header from "assets/img/illusts/header";
 // Lib
@@ -19,7 +19,11 @@ const Masthead: React.FC = () => {
   if (isTablet) backgroundImage = header.tabletPattern1;
 
   return (
-    <SubCourseInfo
+    // <SubCourseInfo
+    //   {...{ title, description, targets, courseInfos, backgroundImage }}
+    //   backgroundColor={color.primary.green4}
+    // /> - 일시적(?)으로 마스터즈 페이지에도 동일한 디자인을 적용하기 위한 주석처리
+    <CourseInfo
       {...{ title, description, targets, courseInfos, backgroundImage }}
       backgroundColor={color.primary.green4}
     />

--- a/src/pages/pre-course/index.tsx
+++ b/src/pages/pre-course/index.tsx
@@ -1,33 +1,35 @@
 import React from "react";
-// Theme
-import GlobalTheme from "lib/context/GlobalTheme";
-import GlobalHeader from "lib/context/GlobalHeader";
-// Components
-import { HomeGlobalNavigationBar, Footer, FAQ } from "components/";
-import { Masthead, Registration, DetailCurriculum, TimeTable } from "pageComponents/pre-course";
-// Assets
-import { SEO_TITLE, SEO_DESCRIPTION } from "assets/static/seo";
-import { INTERNAL } from "assets/static/urls";
+// // Theme
+// import GlobalTheme from "lib/context/GlobalTheme";
+// import GlobalHeader from "lib/context/GlobalHeader";
+// // Components
+// import { HomeGlobalNavigationBar, Footer, FAQ } from "components/";
+// import { Masthead, Registration, DetailCurriculum, TimeTable } from "pageComponents/pre-course";
+// // Assets
+// import { SEO_TITLE, SEO_DESCRIPTION } from "assets/static/seo";
+// import { INTERNAL } from "assets/static/urls";
+import NotFoundPage from "pages/404";
 
 const PreCoursePage: React.FC = () => {
-  return (
-    <GlobalTheme>
-      <GlobalHeader
-        title={SEO_TITLE.PRE_COURSE}
-        description={SEO_DESCRIPTION.PRE_COURSE}
-        url={INTERNAL.PRE_COURSE}
-      />
-      <main style={{ overflowX: "hidden" }}>
-        <HomeGlobalNavigationBar />
-        <Masthead />
-        {/* <Registration /> */}
-        <DetailCurriculum />
-        <TimeTable />
-        <FAQ course="pre-course" />
-        <Footer />
-      </main>
-    </GlobalTheme>
-  );
+  return <NotFoundPage />;
+  // return (
+  //   <GlobalTheme>
+  //     <GlobalHeader
+  //       title={SEO_TITLE.PRE_COURSE}
+  //       description={SEO_DESCRIPTION.PRE_COURSE}
+  //       url={INTERNAL.PRE_COURSE}
+  //     />
+  //     <main style={{ overflowX: "hidden" }}>
+  //       <HomeGlobalNavigationBar />
+  //       <Masthead />
+  //       <Registration />
+  //       <DetailCurriculum />
+  //       <TimeTable />
+  //       <FAQ course="pre-course" />
+  //       <Footer />
+  //     </main>
+  //   </GlobalTheme>
+  // );
 };
 
 export default PreCoursePage;


### PR DESCRIPTION
### 프리코스 페이지 제거
* 글로벌 네비게이션 바의 마스터즈 버튼이 드롭다운메뉴가 아닌 링크 버튼으로 동작되도록 수정
* 메인페이지의 프리코스 링크 마스터즈 링크로 수정
* 프리코스 페이지 404페이지로 수정

### 디자인 수정
* 마스터즈 페이지 디자인 통일
* FAQ컴포넌트에서 사용되지 않는 btnUrl, btnText 주석처리